### PR TITLE
Ajustar posições do banner e da barra de navegação

### DIFF
--- a/style.css
+++ b/style.css
@@ -33,7 +33,6 @@ body {
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
-    padding: 32px 0;
     gap: auto;
     margin: 0 152px;
 }
@@ -82,11 +81,10 @@ body {
 }
 
 .cabecalho__banner {
+    box-sizing: border-box;
     height: 352px;
     background-image: linear-gradient(180deg, rgba(0, 0, 0, 0) 41.15%, rgba(0, 0, 0, 0.8) 100%), url(imagens/banner.png);
-    background-size: 120%;
-    padding: 32px 0;
-    
+    align-items: center;
 }
 
 .cabecalho__banner__texto {
@@ -96,6 +94,7 @@ body {
     display: flex;
     flex-direction: column;
     gap: 16px;
+    padding: 0px;
     box-sizing: border-box;
     color: #FFFFFF;
     font-family: 'Raleway', sans-serif;


### PR DESCRIPTION
- Retirado o padding da class .cabecalho__nav__logoebarra, pois estava invadindo a div abaixo. Ao retirar não mudou a apresentação do site.
- Retirados os atributos padding e backgroup-size da class .cabecalho__banner, também e estavam aferando outras divs próximas. No lugar destes foram utilizados box-sizing e align-itens para ajuste dos elementos internamente na div.